### PR TITLE
Add badge readiness docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,10 @@
+<!--
+Copyright (c) 2026 The Jaeger Authors.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Community Code of Conduct
+
+Jaeger UI follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
+
+Please contact the [Jaeger Maintainers](mailto:cncf-jaeger-maintainers@lists.cncf.io) or the [CNCF Code of Conduct Committee](mailto:conduct@cncf.io) to report violations of the Code of Conduct.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Visualize distributed tracing with Jaeger.
 
 ## Contributing
 
-See [CONTRIBUTING](./CONTRIBUTING.md) for development setup, coding standards, and contribution guidelines.
+See [CONTRIBUTING](./CONTRIBUTING.md) for development setup, coding standards, and contribution guidelines. See [CODE_OF_CONDUCT](./CODE_OF_CONDUCT.md) for community expectations and [OpenSSF Best Practices Badge Readiness](./docs/openssf-best-practices.md) for the repository evidence collected for the `jaeger-ui` badge application.
 
 Stuck somewhere or found a bug? See [Getting in Touch](https://www.jaegertracing.io/get-in-touch/) on how to ask for help.
 

--- a/docs/openssf-best-practices.md
+++ b/docs/openssf-best-practices.md
@@ -1,0 +1,34 @@
+<!--
+Copyright (c) 2026 The Jaeger Authors.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# OpenSSF Best Practices Badge Readiness
+
+This document tracks repository-local evidence for the OpenSSF Best Practices badge application for `github.com/jaegertracing/jaeger-ui`.
+
+GitHub code scanning alert `#10` comes from the Scorecard `CIIBestPracticesID` check. That alert stays open until the repository has an OpenSSF Best Practices badge entry on [bestpractices.dev](https://www.bestpractices.dev/).
+
+## Repository Evidence
+
+- License: [LICENSE](../LICENSE)
+- Contributing guide: [CONTRIBUTING.md](../CONTRIBUTING.md)
+- Project code of conduct: [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
+- Security policy: [SECURITY.md](../SECURITY.md)
+- Release process: [RELEASE.md](../RELEASE.md)
+- Architectural decision records: [docs/adr](./adr)
+- Unit tests workflow: [`.github/workflows/unit-tests.yml`](../.github/workflows/unit-tests.yml)
+- Lint and build workflow: [`.github/workflows/lint-build.yml`](../.github/workflows/lint-build.yml)
+- CodeQL analysis: [`.github/workflows/codeql.yml`](../.github/workflows/codeql.yml)
+- Dependency update automation: [`.github/dependabot.yml`](../.github/dependabot.yml)
+- Scorecard analysis workflow: [`.github/workflows/scorecard.yml`](../.github/workflows/scorecard.yml)
+
+## Remaining Manual Step
+
+The badge state itself is managed outside this repository. A Jaeger UI maintainer must:
+
+1. Create or claim the project entry for `github.com/jaegertracing/jaeger-ui` on [bestpractices.dev](https://www.bestpractices.dev/).
+2. Mark the project as `in progress` or complete the badge criteria there.
+3. Update [README.md](../README.md) with the badge URL once the project entry exists.
+
+Completing step 1 changes the Scorecard signal from `0` to a non-zero badge score, which is the condition needed to resolve alert `#10`.


### PR DESCRIPTION
## Summary
- add a repo-local `CODE_OF_CONDUCT.md`
- document OpenSSF Best Practices badge readiness for `jaeger-ui`
- link the badge-readiness context from the top-level README

## Why this PR is needed
This change addresses GitHub code scanning alert `#10`, the Scorecard `CIIBestPracticesID` finding on the `jaeger-ui` repository.

Although the main `jaeger` repository already has related security and governance material, Scorecard evaluates `github.com/jaegertracing/jaeger-ui` as a separate repository. That means the alert remains open until `jaeger-ui` has its own visible repository-level evidence and its own OpenSSF Best Practices badge entry on `bestpractices.dev`.

This PR handles the repo-side work needed to support that application and to explain why the flag exists on this repository specifically.

## Validation
I ran the required commands. In this mixed Windows and WSL checkout, the results reflect existing environment issues rather than problems caused by this doc-only change:

- `npm run prettier`: passes in WSL, but normalizes a large amount of the shared working tree
- `npm run lint`: fails in WSL because repo shell scripts were not found/executable from this mounted checkout
- `npm test`: `jaeger-ui` tests passed, but the overall workspace command failed because `plexus` could not resolve its Jest setup file in this environment
- `npm run build`: fails in WSL because the optional native Rollup package `@rollup/rollup-linux-x64-gnu` was missing

## Follow-up
A maintainer still needs to create or claim `github.com/jaegertracing/jaeger-ui` on `bestpractices.dev` and move it to at least `in progress` to clear the Scorecard alert.