### PR TITLE
Pin s390x workflow actions to immutable SHAs

### DIFF
--- a/.github/workflows/s390x-build.yaml
+++ b/.github/workflows/s390x-build.yaml
@@ -18,10 +18,10 @@ jobs:
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e2 # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@2b51285047da1547b1b6d0c433e4f9b17d9d6e9d # v3
 
       - name: Cache Docker layers
         uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1


### PR DESCRIPTION
### Motivation
- Replace mutable `@v3` tags for `docker/setup-qemu-action` and `docker/setup-buildx-action` in the s390x CI workflow to mitigate a CI supply-chain risk by pinning to immutable commit SHAs.

### Description
- Update `.github/workflows/s390x-build.yaml` to use `docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e2` and `docker/setup-buildx-action@2b51285047da1547b1b6d0c433e4f9b17d9d6e9d` in place of the mutable `@v3` tags, preserving the intended `v3` targets.

### Testing
- Ran `npm run prettier` (succeeded); attempted `npm run lint`, `npm test`, and `npm run build` but those were blocked/failed due to missing dev tools (`npm-run-all`, `jest`, `vite`) and an engine constraint (`node >=24` required while the environment has `node v20`), so full workspace verification could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b32fb442ec832696f2beb6a2bcd10c)