### PR TITLE
Fix KeyValuePair types in DDG model

### DIFF
--- a/packages/jaeger-ui/src/model/ddg/transformDdgData.ts
+++ b/packages/jaeger-ui/src/model/ddg/transformDdgData.ts
@@ -4,6 +4,7 @@
 import memoizeOne from 'memoize-one';
 import objectHash from 'object-hash';
 
+import { KeyValuePair } from '../../types/trace';
 import {
   PathElem,
   TDdgModel,
@@ -16,9 +17,8 @@ import {
 
 const stringifyEntry = ({ service, operation }: TDdgPayloadEntry) => `${service}\v${operation}`;
 
-// TODO: Everett Tech Debt: Fix KeyValuePair types
-function group(arg: { key: string; value: any }[]): Record<string, any[]> {
-  const result: Record<string, any[]> = {};
+function group(arg: KeyValuePair[]): Record<string, string[]> {
+  const result: Record<string, string[]> = {};
   arg.forEach(({ key, value }) => {
     if (!result[key]) result[key] = [];
     result[key].push(value);

--- a/packages/jaeger-ui/src/model/ddg/types.ts
+++ b/packages/jaeger-ui/src/model/ddg/types.ts
@@ -4,6 +4,7 @@
 import { TVertex } from '@jaegertracing/plexus/lib/types';
 
 import PathElem from './PathElem';
+import { KeyValuePair } from '../../types/trace';
 
 export { default as PathElem } from './PathElem';
 
@@ -41,11 +42,7 @@ export type TDdgPayloadEntry = {
 
 export type TDdgPayloadPath = {
   path: TDdgPayloadEntry[];
-  // TODO: Everett Tech Debt: Fix KeyValuePair types
-  attributes: {
-    key: 'exemplar_trace_id';
-    value: string;
-  }[];
+  attributes: KeyValuePair[];
 };
 
 export type TDdgPayload = {


### PR DESCRIPTION
Fixes technical debt in the DDG model by replacing inline KeyValuePair type definitions with the standard shared type. This includes updating the TDdgPayloadPath type and the group utility function in the DDG transformation logic.

---
*PR created automatically by Jules for task [6525103373172759572](https://jules.google.com/task/6525103373172759572) started by @jkowall*