### PR TITLE
🧪 [testing improvement] Add error path test for tryParseMultiLineInput in readJsonFile

### DIFF
--- a/packages/jaeger-ui/src/utils/readJsonFile.test.js
+++ b/packages/jaeger-ui/src/utils/readJsonFile.test.js
@@ -87,40 +87,46 @@ describe('fileReader.readJsonFile', () => {
     return expect(p).resolves.toMatchObject(expectedOutput);
   });
 
-  it('handles FileReader error', () => {
-    const file = new File([''], 'error.json');
-    const mockReader = { readAsText: jest.fn(), onerror: null, error: new Error('Read error') };
+  describe('FileReader mocking', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
 
-    jest.spyOn(window, 'FileReader').mockImplementation(() => mockReader);
-    const promise = readJsonFile({ file });
+    it('handles FileReader error', () => {
+      const file = new File([''], 'error.json');
+      const mockReader = { readAsText: jest.fn(), onerror: null, error: new Error('Read error') };
 
-    mockReader.onerror();
+      jest.spyOn(window, 'FileReader').mockImplementation(() => mockReader);
+      const promise = readJsonFile({ file });
 
-    return expect(promise).rejects.toThrow(/Read error/);
-  });
+      mockReader.onerror();
 
-  it('handles FileReader abort', () => {
-    const file = new File([''], 'abort.json');
-    const mockReader = { readAsText: jest.fn(), onabort: null };
+      return expect(promise).rejects.toThrow(/Read error/);
+    });
 
-    jest.spyOn(window, 'FileReader').mockImplementation(() => mockReader);
-    const promise = readJsonFile({ file });
+    it('handles FileReader abort', () => {
+      const file = new File([''], 'abort.json');
+      const mockReader = { readAsText: jest.fn(), onabort: null };
 
-    mockReader.onabort();
+      jest.spyOn(window, 'FileReader').mockImplementation(() => mockReader);
+      const promise = readJsonFile({ file });
 
-    return expect(promise).rejects.toThrow(/aborted/);
-  });
+      mockReader.onabort();
 
-  it('rejects if FileReader result is not a string', () => {
-    const file = new File(['{ "test": true }'], 'dummy.json');
-    const mockReader = { readAsText: jest.fn(), onload: null, result: {} };
+      return expect(promise).rejects.toThrow(/aborted/);
+    });
 
-    jest.spyOn(window, 'FileReader').mockImplementation(() => mockReader);
-    const promise = readJsonFile({ file });
+    it('rejects if FileReader result is not a string', () => {
+      const file = new File(['{ "test": true }'], 'dummy.json');
+      const mockReader = { readAsText: jest.fn(), onload: null, result: {} };
 
-    mockReader.onload();
+      jest.spyOn(window, 'FileReader').mockImplementation(() => mockReader);
+      const promise = readJsonFile({ file });
 
-    return expect(promise).rejects.toThrow(/Invalid result type/);
+      mockReader.onload();
+
+      return expect(promise).rejects.toThrow(/Invalid result type/);
+    });
   });
 
   it('rejects multi-line JSON with a malformed line', () => {

--- a/packages/jaeger-ui/src/utils/readJsonFile.test.js
+++ b/packages/jaeger-ui/src/utils/readJsonFile.test.js
@@ -87,16 +87,25 @@ describe('fileReader.readJsonFile', () => {
     return expect(p).resolves.toMatchObject(expectedOutput);
   });
 
+  it('rejects multi-line JSON with a malformed line', () => {
+    const fileContent = '{"a":1}\n{"b":';
+    const file = new File([fileContent], 'multi-error.json', { type: 'application/json' });
+    const p = readJsonFile({ file });
+    return expect(p).rejects.toThrow(/Error parsing JSON at line 2:/);
+  });
+
   describe('FileReader mocking', () => {
+    let fileReaderSpy;
+
     afterEach(() => {
-      jest.restoreAllMocks();
+      fileReaderSpy.mockRestore();
     });
 
     it('handles FileReader error', () => {
       const file = new File([''], 'error.json');
       const mockReader = { readAsText: jest.fn(), onerror: null, error: new Error('Read error') };
 
-      jest.spyOn(window, 'FileReader').mockImplementation(() => mockReader);
+      fileReaderSpy = jest.spyOn(window, 'FileReader').mockImplementation(() => mockReader);
       const promise = readJsonFile({ file });
 
       mockReader.onerror();
@@ -108,7 +117,7 @@ describe('fileReader.readJsonFile', () => {
       const file = new File([''], 'abort.json');
       const mockReader = { readAsText: jest.fn(), onabort: null };
 
-      jest.spyOn(window, 'FileReader').mockImplementation(() => mockReader);
+      fileReaderSpy = jest.spyOn(window, 'FileReader').mockImplementation(() => mockReader);
       const promise = readJsonFile({ file });
 
       mockReader.onabort();
@@ -120,19 +129,12 @@ describe('fileReader.readJsonFile', () => {
       const file = new File(['{ "test": true }'], 'dummy.json');
       const mockReader = { readAsText: jest.fn(), onload: null, result: {} };
 
-      jest.spyOn(window, 'FileReader').mockImplementation(() => mockReader);
+      fileReaderSpy = jest.spyOn(window, 'FileReader').mockImplementation(() => mockReader);
       const promise = readJsonFile({ file });
 
       mockReader.onload();
 
       return expect(promise).rejects.toThrow(/Invalid result type/);
     });
-  });
-
-  it('rejects multi-line JSON with a malformed line', () => {
-    const fileContent = '{"a":1}\n{"b":';
-    const file = new File([fileContent], 'multi-error.json', { type: 'application/json' });
-    const p = readJsonFile({ file });
-    return expect(p).rejects.toThrow(/Error parsing JSON at line 2:/);
   });
 });

--- a/packages/jaeger-ui/src/utils/readJsonFile.test.js
+++ b/packages/jaeger-ui/src/utils/readJsonFile.test.js
@@ -122,4 +122,11 @@ describe('fileReader.readJsonFile', () => {
 
     return expect(promise).rejects.toThrow(/Invalid result type/);
   });
+
+  it('rejects multi-line JSON with a malformed line', () => {
+    const fileContent = '{"a":1}\n{"b":';
+    const file = new File([fileContent], 'multi-error.json', { type: 'application/json' });
+    const p = readJsonFile({ file });
+    return expect(p).rejects.toThrow(/Error parsing JSON at line 2:/);
+  });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the missing error path test for `tryParseMultiLineInput` in `readJsonFile.ts`.
📊 **Coverage:** A new test scenario is now covered where a malformed multi-line JSON string is provided, and the test asserts that the returned promise rejects with an error message containing the correct line number.
✨ **Result:** Increased test coverage for the JSON parsing utility, specifically for error conditions in multi-line input handling.

---
*PR created automatically by Jules for task [18060541359049267331](https://jules.google.com/task/18060541359049267331) started by @jkowall*