### PR TITLE
🧹 chore: rename parameters in IScroller interface in ScrollManager.ts

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/ScrollManager.ts
+++ b/packages/jaeger-ui/src/components/TracePage/ScrollManager.ts
@@ -27,9 +27,8 @@ export type Accessors = {
 };
 
 interface IScroller {
-  scrollTo: (rowIndex: number) => void;
-  // TODO arg names throughout
-  scrollBy: (rowIndex: number, opt?: boolean) => void;
+  scrollTo: (y: number) => void;
+  scrollBy: (yDelta: number, appendToLast?: boolean) => void;
 }
 
 /**


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is the non-descriptive and misleading parameter names in the `IScroller` interface within `ScrollManager.ts`. 

💡 **Why:** This improves maintainability and readability by clarifying the units and purpose of the parameters (pixel coordinates and deltas, not row indices), and by aligning the interface with the `scroll-page.ts` utility functions it wraps.

✅ **Verification:** I have confirmed the usage in `ScrollManager.ts` (where `_scrollPast` calculates pixel `y` from row index) and the implementation in `scroll-page.ts` (where `y`, `yDelta`, and `appendToLast` are used). 

✨ **Result:** The code is now more readable, and a stale TODO comment has been resolved.

---
*PR created automatically by Jules for task [9759916406394628892](https://jules.google.com/task/9759916406394628892) started by @jkowall*