### PR TITLE
🔒 Prevent XSS in DdgNodeContent by using textContent for measurements

### DIFF
--- a/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/calc-positioning.ts
+++ b/packages/jaeger-ui/src/components/DeepDependencies/Graph/DdgNodeContent/calc-positioning.ts
@@ -141,7 +141,7 @@ const calcRects = _memoize(
   function calcRects(str: string | string[], span: HTMLSpanElement): TRect[] {
     const lengths = (Array.isArray(str) ? [`${str.length} Operations}`] : str.match(WORD_RX) || [str]).map(
       s => {
-        span.innerHTML = s;
+        span.textContent = s;
         return span.getClientRects()[0].width;
       }
     );


### PR DESCRIPTION
🎯 **What:** Fixed a Cross-Site Scripting (XSS) vulnerability in `calc-positioning.ts` where `innerHTML` was used to set the content of a measurement span.
⚠️ **Risk:** If a service or operation name contains malicious HTML/scripts, they could be executed when the graph node dimensions are calculated.
🛡️ **Solution:** Replaced `innerHTML` with `textContent` to ensure that input strings are treated as plain text during measurement, preventing any script execution.

---
*PR created automatically by Jules for task [10070864440845266410](https://jules.google.com/task/10070864440845266410) started by @jkowall*