### PR TITLE
Optimize TraceStatistics grouping

### DIFF
--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/index.test.jsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/index.test.jsx
@@ -137,6 +137,70 @@ describe('<TraceTagOverview>', () => {
     expect(cells.length).toBeGreaterThan(0);
   });
 
+  it('groups detail rows under their matching parent rows', async () => {
+    let componentRef;
+    const TestWrapper = () => {
+      const ref = React.useRef();
+      componentRef = ref;
+      return <TraceStatistics ref={ref} {...defaultProps} />;
+    };
+
+    const { container } = render(<TestWrapper />);
+
+    const makeRow = (name, isDetail, parentElement, overrides = {}) => ({
+      name,
+      hasSubgroupValue: !isDetail,
+      searchColor: 'transparent',
+      color: '#000',
+      key: name,
+      isDetail,
+      parentElement,
+      count: 1,
+      total: 100,
+      avg: 50,
+      min: 10,
+      max: 90,
+      selfTotal: 80,
+      selfAvg: 40,
+      selfMin: 5,
+      selfMax: 75,
+      percent: 80,
+      colorToPercent: '#fff',
+      traceID: name,
+      ...overrides,
+    });
+
+    await waitFor(() => {
+      if (componentRef.current) {
+        componentRef.current.setState({
+          ...componentRef.current.state,
+          tableValue: [
+            makeRow('parent-a', false, 'none'),
+            makeRow('detail-a1', true, 'parent-a', { hasSubgroupValue: false }),
+            makeRow('detail-a2', true, 'parent-a', { hasSubgroupValue: false }),
+            makeRow('parent-b', false, 'none'),
+            makeRow('detail-b1', true, 'parent-b', { hasSubgroupValue: false }),
+          ],
+        });
+      }
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('parent-a')).toBeInTheDocument();
+      expect(screen.getByText('parent-b')).toBeInTheDocument();
+      expect(screen.getByText('detail-a1')).toBeInTheDocument();
+      expect(screen.getByText('detail-a2')).toBeInTheDocument();
+      expect(screen.getByText('detail-b1')).toBeInTheDocument();
+    });
+
+    await waitFor(() => {
+      const parentRows = container.querySelectorAll('tbody tr.ant-table-row-level-0');
+      const childRows = container.querySelectorAll('tbody tr.ant-table-row-level-1');
+      expect(parentRows).toHaveLength(2);
+      expect(childRows).toHaveLength(3);
+    });
+  });
+
   it('check togglePopup', async () => {
     let componentRef;
     const TestWrapper = () => {

--- a/packages/jaeger-ui/src/components/TracePage/TraceStatistics/index.tsx
+++ b/packages/jaeger-ui/src/components/TracePage/TraceStatistics/index.tsx
@@ -315,20 +315,42 @@ export default class TraceStatistics extends Component<Props, State> {
      * Pre-process the table data into groups and sub-groups
      */
     const groupAndSubgroupSpanData = (tableValue: ITableSpan[]): ITableSpan[] => {
-      const withDetail: ITableSpan[] = tableValue.filter((val: ITableSpan) => val.isDetail);
-      const withoutDetail: ITableSpan[] = tableValue.filter((val: ITableSpan) => !val.isDetail);
+      const withDetail: ITableSpan[] = [];
+      const withoutDetail: ITableSpan[] = [];
+      for (let i = 0; i < tableValue.length; i++) {
+        const val = tableValue[i];
+        if (val.isDetail) {
+          withDetail.push(val);
+        } else {
+          withoutDetail.push(val);
+        }
+      }
+
+      const withDetailByParent = new Map<string, ITableSpan[]>();
+      for (let i = 0; i < withDetail.length; i++) {
+        const val = withDetail[i];
+        const { parentElement } = val;
+        let list = withDetailByParent.get(parentElement);
+        if (!list) {
+          list = [];
+          withDetailByParent.set(parentElement, list);
+        }
+        list.push(val);
+      }
+
       for (let i = 0; i < withoutDetail.length; i++) {
-        let newArr = withDetail.filter(value => value.parentElement === withoutDetail[i].name);
-        newArr = newArr.map((value, index) => {
+        const parentName = withoutDetail[i].name;
+        const matchingDetails = withDetailByParent.get(parentName) || [];
+        const children = matchingDetails.map((value, index) => {
           const _key = {
             key: `${i}-${index}`,
           };
-          const value2 = { ...value, ..._key };
-          return value2;
+          return { ...value, ..._key };
         });
+
         const child = {
           key: i.toString(),
-          children: newArr,
+          children,
         };
         withoutDetail[i] = { ...withoutDetail[i], ...child };
       }


### PR DESCRIPTION
### Summary
This PR optimizes `groupAndSubgroupSpanData()` in `TraceStatistics` by pre-grouping detail rows in a `Map` instead of repeatedly filtering the full list.

### What changed
- replaced the repeated detail-row filtering with a precomputed parent-to-children map in `TraceStatistics`
- added a focused regression test that verifies grouped detail rows render under the correct parent rows

### Benchmark
Focused local benchmark of the old vs new `groupAndSubgroupSpanData()` implementation on a synthetic 42k-row dataset (`7000` parent rows, `5` detail rows each), using median runtime across repeated runs:

- baseline median: `1203.24ms`
- optimized median: `9.34ms`
- improvement: `99.22%` reduction in runtime
- speedup: about `128.9x`

This benchmark isolates the grouping step itself, so it is more aggressive than the earlier broader Jules estimate.

### Validation
- `npm run fmt`
- `npm run lint`
- `npm test` (`packages/jaeger-ui` passes; the root command still reports existing `packages/plexus` test failures unrelated to this PR)
- `npm run build`

### Notes
- `changelog:skip` label applied
- unrelated drifted changes were removed so the PR stays limited to the `TraceStatistics` optimization and its regression test